### PR TITLE
added navbar with burgermenu and a slideopen menu for page navigation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4,6 +4,68 @@
     font-family: "Montserrat";
 }
 
+/* Navbar menu och burger */
+
+.navbar {
+  display: flex;
+  justify-content: space-between; 
+  align-items: center;
+  padding: 1rem 1.2rem;
+  background: white;
+  border-bottom: 1px solid #e4e4e4;
+  position: sticky;
+  top: 0;
+  
+}
+
+.logo {
+  font-size: 1.2rem;
+  font-weight: 700;
+}
+
+.burger-btn {
+  background: none;
+  border: none;
+  font-size: 1.8rem;
+  cursor: pointer;
+}
+
+.menu-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.4);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s;
+}
+
+.menu-overlay.open {
+  opacity: 1;
+  pointer-events: auto;
+  z-index: 1;
+}
+
+.menu-panel {
+  position: absolute;
+  right: 0;
+  top: 0;
+  height: 100vh;
+  width: 40%;      /* mobil */
+  max-width: 250px; /* desktop */
+  background: white;
+  padding: 2rem;
+  box-shadow: -4px 0 20px rgba(0,0,0,0.2);
+  transform: translateX(100%);
+  transition: transform 0.3s ease;
+}
+
+.menu-overlay.open .menu-panel {
+  transform: translateX(0);
+}
+
+
+
+/* Recipe cards CSS */
 
  .recipe-grid {
   display: grid;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,5 @@
+import Navbar from "./components/Navbar";
+import SlideOutMenu from "./components/SlideOutMenu";
 import RecipeCards from "./components/RecipeCards";
 import SearchBar from "./components/search/SearchContainer";
 
@@ -5,6 +7,8 @@ function App() {
   return (
     <>
     <SearchBar />
+    <Navbar />
+    <SlideOutMenu />
     <RecipeCards />
     </>
     

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,19 @@
+import { useMenuStore } from "../store/menuStore";
+
+
+function Navbar() {
+    const toggleMenu = useMenuStore((state) => state.toggle);
+  return (
+    <nav className="navbar">
+      <div className="logo">Recipe finder</div>
+
+      <button className="burgermenu" onClick={toggleMenu}>
+        ☰
+      </button>
+    </nav>
+  );
+}
+  
+
+export default Navbar
+

--- a/src/components/SlideOutMenu.tsx
+++ b/src/components/SlideOutMenu.tsx
@@ -1,0 +1,22 @@
+import { useMenuStore } from "../store/menuStore";
+
+function SlideOutMenu() {
+    const isOpen = useMenuStore((state) => state.isOpen)
+    const close = useMenuStore((state) => state.close)
+
+  return (
+        <div className={`menu-overlay ${isOpen ? "open" : ""}`} onClick={close}>
+            <div className="menu-panel" onClick={(e) => e.stopPropagation()}>
+                <button className="close-menu-btn" onClick={() => {close();}}
+                >✕</button>
+
+        <h3>Meny</h3>
+        <a href="/">Hem</a>
+        
+        <a href="/favorites">Favoriter</a>
+      </div>
+    </div>
+  )
+}
+
+export default SlideOutMenu

--- a/src/store/menuStore.ts
+++ b/src/store/menuStore.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+type MenuStore = {
+    isOpen: boolean
+    toggle: () => void
+    close: () => void
+}
+
+export const useMenuStore = create<MenuStore>((set) => ({
+    isOpen: false,
+    toggle: () => set((s) => ({ isOpen: !s.isOpen})),
+    close: () => set(() => ({ isOpen: false }))
+}))


### PR DESCRIPTION
* Added `Navbar` component with a burger menu button that toggles the slide-out menu. (`src/components/Navbar.tsx`)
* Added `SlideOutMenu` component that displays navigation links and can be opened/closed via overlay or close button. (`src/components/SlideOutMenu.tsx`)
* Integrated both components into the main app layout for consistent navigation. (`src/App.tsx`)

* Implemented `menuStore` using Zustand to manage the open/close state of the slide-out menu. (`src/store/menuStore.ts`)