### PR TITLE
feat: add intolerance filtering to advanced search

### DIFF
--- a/src/components/search/AdvancedFilters.tsx
+++ b/src/components/search/AdvancedFilters.tsx
@@ -1,5 +1,41 @@
-function AdvancedFilters() {
-  return <></>;
+import { useState } from "react";
+import { INTOLERANCES, type Intolerance } from "../../constants/intolerances";
+
+function AdvancedFilters({
+  onChange,
+}: {
+  onChange: (intolerances: Intolerance[]) => void;
+}) {
+  const [selected, setSelected] = useState<Intolerance[]>([]);
+
+  const toggle = (value: Intolerance) => {
+    const newSelected = selected.includes(value)
+      ? selected.filter((v) => v !== value)
+      : [...selected, value];
+
+    setSelected(newSelected);
+    onChange(newSelected);
+  };
+
+  const createCheckboxes = () => {
+    return INTOLERANCES.map((intolerance) => {
+      const slug = intolerance.toLowerCase().replace(/\s+/g, "-");
+
+      return (
+        <div key={intolerance}>
+          <label htmlFor={`intolerance-${slug}`}>{intolerance}</label>
+          <input
+            type="checkbox"
+            id={`intolerance-${slug}`}
+            checked={selected.includes(intolerance)}
+            onChange={() => toggle(intolerance)}
+          />
+        </div>
+      );
+    });
+  };
+
+  return <>{createCheckboxes()}</>;
 }
 
 export default AdvancedFilters;

--- a/src/components/search/SearchContainer.tsx
+++ b/src/components/search/SearchContainer.tsx
@@ -5,13 +5,27 @@ import SearchModeToggle from "./SearchModeToggle";
 import { useState } from "react";
 import { DEFAULT_RECIPE_COUNT } from "../../types/api";
 import MockRecipesQuickList from "./MockRecipesQuickList";
+import { type Intolerance } from "../../constants/intolerances";
 
 function SearchContainer() {
   const [searchValue, setSearchValue] = useState<string>("");
+  const [intolerances, setIntolerances] = useState<Intolerance[]>([]);
   const { search } = useSearchResultsStore();
 
   const handleSearch = (query: string): void => {
-    search({ query, number: DEFAULT_RECIPE_COUNT });
+    // console.log("Current intolerances state:", intolerances);
+    const searchOptions = {
+      query,
+      number: DEFAULT_RECIPE_COUNT,
+      intolerances: intolerances.join(",") || undefined,
+    };
+    // console.log("SearchOptions about to send:", searchOptions);
+    search(searchOptions);
+  };
+
+  const handleIntolerancesChange = (intolerances: Intolerance[]) => {
+    // console.log("Intolerances updated:", intolerances);
+    setIntolerances(intolerances);
   };
 
   return (
@@ -22,7 +36,7 @@ function SearchContainer() {
         onSearch={handleSearch}
         value={searchValue}
       />
-      <AdvancedFilters />
+      <AdvancedFilters onChange={handleIntolerancesChange} />
       <MockRecipesQuickList onRecipeClick={handleSearch} />
     </>
   );

--- a/src/constants/intolerances.ts
+++ b/src/constants/intolerances.ts
@@ -1,0 +1,16 @@
+export const INTOLERANCES = [
+  "Dairy",
+  "Egg",
+  "Gluten",
+  "Grain",
+  "Peanut",
+  "Seafood",
+  "Sesame",
+  "Shellfish",
+  "Soy",
+  "Sulfite",
+  "Tree Nut",
+  "Wheat",
+] as const;
+
+export type Intolerance = typeof INTOLERANCES[number];

--- a/src/store/searchResultsStore.ts
+++ b/src/store/searchResultsStore.ts
@@ -25,6 +25,7 @@ export const useSearchResultsStore = create<RecipeState>((set) => ({
 
     try {
       const options: SearchOptions = {
+        ...params,
         query: trimmed,
         number: params.number ?? DEFAULT_RECIPE_COUNT,
       };


### PR DESCRIPTION
## Summary
Add dietary intolerance filtering to advanced recipe search. Users can now select multiple intolerance types (gluten, dairy, soy, etc.) to filter recipe results.


## Key Changes
* New file: `src/constants/intolerances.ts` with INTOLERANCES constant and Intolerance type
* Updated `src/components/search/AdvancedFilters.tsx`: Checkbox component with toggle logic
* Updated `src/components/search/SearchContainer.tsx`: Manages intolerances state, formats for API
* Updated `src/store/searchResultsStore.ts`: Uses spread pattern to pass all SearchOptions params
* Updated `src/types/api.ts`: Added intolerances field to SearchOptions

## Limitations
* `AdvancedFilters` has no styling.
* Filter panel visibility is not toggleable yet.

**Planned follow-ups:**
* basic styling
* show/hide filter panel toggle 
* clear all filters button
* more filtering options (e.g. *maxReadyTime*, *diet*, *type*)