### PR TITLE
feat: add search filters store, types, and toggle helpers

### DIFF
--- a/src/store/searchFiltersStore.ts
+++ b/src/store/searchFiltersStore.ts
@@ -1,0 +1,44 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { toggleObjectInArray } from "../utils/toggleHelpers";
+import {
+  type Filters,
+  type FavoriteFilter,
+  type SearchFiltersStore,
+} from "../types/filters";
+
+export const useSearchFiltersStore = create<SearchFiltersStore>()(
+  persist(
+    (set) => ({
+      filters: {
+        intolerances: [],
+        diets: [],
+        maxReadyTime: null,
+      },
+      favoriteFilters: [],
+      setFilters: (filters: Filters) => set({ filters }),
+      toggleFavoriteFilter: (favorite: FavoriteFilter) => {
+        set((state) => ({
+          favoriteFilters: toggleObjectInArray(state.favoriteFilters, favorite),
+        }));
+      },
+      saveFavorite: (name: string) =>
+        set((state) => ({
+          favoriteFilters: [
+            ...state.favoriteFilters,
+            { id: crypto.randomUUID(), name, filters: state.filters },
+          ],
+        })),
+      loadFavorite: (favorite: Filters) => set({ filters: favorite }),
+      clearFilters: () =>
+        set({
+          filters: {
+            intolerances: [],
+            diets: [],
+            maxReadyTime: null,
+          },
+        }),
+    }),
+    { name: "searchFilters" }
+  )
+);

--- a/src/types/filters.ts
+++ b/src/types/filters.ts
@@ -1,0 +1,21 @@
+export type Filters = {
+  intolerances: string[];
+  diets: string[];
+  maxReadyTime: number | null;
+};
+
+export type FavoriteFilter = {
+  id: string;
+  name: string;
+  filters: Filters;
+};
+
+export type SearchFiltersStore = {
+  filters: Filters;
+  favoriteFilters: FavoriteFilter[];
+  setFilters: (filters: Filters) => void;
+  toggleFavoriteFilter: (favorite: FavoriteFilter) => void;
+  saveFavorite: (name: string) => void;
+  loadFavorite: (favorite: Filters) => void;
+  clearFilters: () => void;
+};

--- a/src/utils/toggleHelpers.ts
+++ b/src/utils/toggleHelpers.ts
@@ -1,0 +1,16 @@
+// Toggle primitive values (e.g. string, number, boolean)
+export function togglePrimitiveInArray<T>(array: readonly T[], value: T): T[] {
+  return array.includes(value)
+    ? array.filter((v) => v !== value)
+    : [...array, value];
+}
+
+// Toggle objects based on 'id' property
+export function toggleObjectInArray<T extends { id: string }>(
+  array: readonly T[],
+  item: T
+): T[] {
+  return array.some((obj) => obj.id === item.id)
+    ? array.filter((obj) => obj.id !== item.id)
+    : [...array, item];
+}


### PR DESCRIPTION
### State management: Add Zustand store for search filters and favorite filters

* Added `useSearchFiltersStore` in `src/store/searchFiltersStore.ts`, implementing a Zustand-based store with persistence for managing search filters and favorite filters
* Includes actions to set, clear, save, load, and toggle favorite filter sets.

### Type definitions:

* Introduced new types in `src/types/filters.ts` for `Filters`, `FavoriteFilter`, and the `SearchFiltersStore` interface, defining the structure and actions for filter management.

### Utility: Add reusable toggle helpers for primitives and objects

* Added `togglePrimitiveInArray` and `toggleObjectInArray` helper functions in `src/utils/toggleHelpers.ts` to handle toggling primitive values and objects (by `id`) in arrays, supporting the store's actions.

### UI and Functionality: No effect
* No UI or functional changes yet; new logic will be integrated in a follow-up PR