### PR TITLE
feat(search): improve sort options and UI for ingredient-based searches

### DIFF
--- a/cypress/e2e/spec.cy.ts
+++ b/cypress/e2e/spec.cy.ts
@@ -133,8 +133,9 @@ describe("Recipe App", () => {
 
       // Navigate away and back
       cy.get(".nav-menu-btn").click();
-      cy.contains("a", "Recipe Finder").click();
-      cy.visit("http://localhost:5173/userapi");
+      cy.contains("a", "Search Recipes").click();
+      cy.get(".nav-menu-btn").click();
+      cy.contains("a", "Get Started").click();
 
       // Verify the key is still there
       cy.get("#spoonacular-api-key").should("have.value", testApiKey);

--- a/src/components/search/AdvancedFilters.tsx
+++ b/src/components/search/AdvancedFilters.tsx
@@ -8,18 +8,18 @@ import {
   type Cuisine,
   MEAL_TYPES,
   type MealType,
-  RECIPE_SORT_OPTIONS,
   type RecipeSortOption,
   MAX_READY_TIME_OPTIONS,
   type MaxReadyTimeOption,
 } from "../../constants/";
-import type { FilterSectionKey } from "../../types";
+import type { FilterSectionKey, SearchMode } from "../../types";
+import { getValidSortOptions } from "../../utils/sortOptionsFilter";
 
 import { PillGroup, SingleSelectDropdown, ToggleFiltersButton } from ".";
 import { togglePrimitiveInArray } from "../../utils/toggleHelpers";
 import { useSearchFiltersStore } from "../../store/searchFiltersStore";
 
-function AdvancedFilters() {
+function AdvancedFilters({ searchMode }: { searchMode: SearchMode }) {
   const [filterSections, setFilterSections] = useState<
     Record<FilterSectionKey, boolean>
   >({
@@ -38,12 +38,8 @@ function AdvancedFilters() {
     (state) => state.filters.maxReadyTime
   );
   const sort = useSearchFiltersStore((state) => state.filters.sort);
-  const sortDirection = useSearchFiltersStore(
-    (state) => state.filters.sortDirection
-  );
   const setFilter = useSearchFiltersStore((state) => state.setFilter);
   const clearFilters = useSearchFiltersStore((state) => state.clearFilters);
-
   const handleToggleSection = (section: FilterSectionKey) => {
     setFilterSections((prev) => ({
       ...prev,
@@ -140,18 +136,20 @@ function AdvancedFilters() {
               options={MAX_READY_TIME_OPTIONS}
               onChange={(value) => setFilter("maxReadyTime", value)}
             />
-            <SingleSelectDropdown<RecipeSortOption>
-              label="Sort By"
-              value={sort}
-              options={RECIPE_SORT_OPTIONS}
-              onChange={(value) => setFilter("sort", value)}
-            />
-            <SingleSelectDropdown<"asc" | "desc">
+            {searchMode === "ingredients" && (
+              <SingleSelectDropdown<RecipeSortOption>
+                label="Sort By"
+                value={sort}
+                options={getValidSortOptions(searchMode)}
+                onChange={(value) => setFilter("sort", value)}
+              />
+            )}
+            {/* <SingleSelectDropdown<"asc" | "desc">
               label="Sort Direction"
               value={sortDirection}
               options={["asc", "desc"]}
               onChange={(value) => setFilter("sortDirection", value)}
-            />
+            /> */}
           </div>
         )}
       </>

--- a/src/components/search/SearchContainer.tsx
+++ b/src/components/search/SearchContainer.tsx
@@ -88,7 +88,7 @@ function SearchContainer() {
               </button>
             )}
           </div>
-          {showFilters && <AdvancedFilters />}
+          {showFilters && <AdvancedFilters searchMode={searchMode}/>}
         </div>
       </div>
     </>

--- a/src/constants/recipeSortOptions.ts
+++ b/src/constants/recipeSortOptions.ts
@@ -1,5 +1,4 @@
 export const RECIPE_SORT_OPTIONS = [
-  "", // "Closest Match"
   "meta-score", // "Most Relevant"
   "time",
   "max-used-ingredients",

--- a/src/utils/searchOptionBuilders.ts
+++ b/src/utils/searchOptionBuilders.ts
@@ -23,8 +23,10 @@ export const buildDefaultSearchMode = (
   query: string,
   filters: Filters
 ): SearchOptions => ({
-  ...baseSearchParams(filters),
   query,
+  sort: "meta-score",
+  sortDirection: "desc",
+  ...baseSearchParams(filters),
 });
 
 export const buildIngredientsSearchMode = (
@@ -33,7 +35,7 @@ export const buildIngredientsSearchMode = (
 ): SearchOptions => ({
   includeIngredients,
   fillIngredients: true,
-  sort: "max-used-ingredients" as RecipeSortOption,
+  sort: "min-missing-ingredients" as RecipeSortOption,
   ignorePantry: true,
   ...baseSearchParams(filters),
 });

--- a/src/utils/searchOptionBuilders.ts
+++ b/src/utils/searchOptionBuilders.ts
@@ -4,7 +4,9 @@ import type { RecipeSortOption } from "../constants";
 
 export const formatFilters = (filters: Filters) => ({
   ...(filters.diet.length && { diet: filters.diet.join(",") }),
-  ...(filters.intolerances.length && { intolerances: filters.intolerances.join(",") }),
+  ...(filters.intolerances.length && {
+    intolerances: filters.intolerances.join(","),
+  }),
   ...(filters.cuisine && { cuisine: filters.cuisine }),
   ...(filters.type && { type: filters.type }),
   ...(filters.maxReadyTime != null && { maxReadyTime: filters.maxReadyTime }),
@@ -23,22 +25,31 @@ export const buildDefaultSearchMode = (
   query: string,
   filters: Filters
 ): SearchOptions => ({
+  ...baseSearchParams(filters),
   query,
   sort: "meta-score",
   sortDirection: "desc",
-  ...baseSearchParams(filters),
 });
+
+const ingredientSortDirection = (sort: RecipeSortOption) =>
+  sort === "max-used-ingredients" ? "desc" : "asc";
 
 export const buildIngredientsSearchMode = (
   includeIngredients: string,
   filters: Filters
-): SearchOptions => ({
-  includeIngredients,
-  fillIngredients: true,
-  sort: "min-missing-ingredients" as RecipeSortOption,
-  ignorePantry: true,
-  ...baseSearchParams(filters),
-});
+): SearchOptions => {
+  const sort = filters.sort ?? ("min-missing-ingredients" as RecipeSortOption);
+  const sortDirection = ingredientSortDirection(sort);
+
+  return {
+    ...baseSearchParams(filters),
+    includeIngredients,
+    fillIngredients: true,
+    sort,
+    sortDirection,
+    ignorePantry: true,
+  };
+};
 
 export const searchModeBuilders: Record<
   SearchMode,

--- a/src/utils/searchOptionBuilders.ts
+++ b/src/utils/searchOptionBuilders.ts
@@ -31,11 +31,11 @@ export const buildIngredientsSearchMode = (
   includeIngredients: string,
   filters: Filters
 ): SearchOptions => ({
-  ...baseSearchParams(filters),
   includeIngredients,
   fillIngredients: true,
   sort: "max-used-ingredients" as RecipeSortOption,
   ignorePantry: true,
+  ...baseSearchParams(filters),
 });
 
 export const searchModeBuilders: Record<

--- a/src/utils/sortOptionsFilter.ts
+++ b/src/utils/sortOptionsFilter.ts
@@ -1,0 +1,17 @@
+import type { SearchMode } from "../types";
+import { RECIPE_SORT_OPTIONS, type RecipeSortOption } from "../constants";
+
+const INGREDIENT_SORTS: ReadonlyArray<RecipeSortOption> = [
+  "max-used-ingredients",
+  "min-missing-ingredients",
+];
+
+const INGREDIENT_OPTIONS = RECIPE_SORT_OPTIONS.filter((option) =>
+  INGREDIENT_SORTS.includes(option)
+);
+const DEFAULT_OPTIONS = RECIPE_SORT_OPTIONS.filter((option) =>
+  !INGREDIENT_SORTS.includes(option)
+);
+
+export const getValidSortOptions = (mode: SearchMode): RecipeSortOption[] =>
+  mode === "ingredients" ? INGREDIENT_OPTIONS : DEFAULT_OPTIONS;


### PR DESCRIPTION
This pull request updates the recipe search functionality to improve how sort options are handled and displayed.

- Adds a utility (`getValidSortOptions`) to filter sort options by search mode, ensuring ingredient-specific sorts only appear when relevant.
- Updates `AdvancedFilters` to use this utility and only show the sort dropdown for ingredient searches.
- Refactors default sort and direction logic for ingredient searches; removes the "Closest Match" empty string from `RECIPE_SORT_OPTIONS`.

**Minor Fix:**
- Updates Cypress test to match nav menu labels.